### PR TITLE
fixed issue #16

### DIFF
--- a/epconversions/epconversions.py
+++ b/epconversions/epconversions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Santosh Philip
+# Copyright (c) 2023-2024 Santosh Philip
 # =======================================================================
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/epconversions/epconversions.py
+++ b/epconversions/epconversions.py
@@ -1001,6 +1001,10 @@ def _doconversion(
     :param reverse: if True, use 1/conv or reverse of the rule
     :returns new_value: the converted value
     """
+    try:
+        val = float(val)
+    except (ValueError, TypeError) as e:
+        pass
     if reverse:
         try:
             conv = 1 / conv  # type: ignore

--- a/tests/test_epconversions.py
+++ b/tests/test_epconversions.py
@@ -122,6 +122,14 @@ from epconversions import epconversions
         ),  # val, siunit, ipunit, unitstr, wrapin, expected
         # unitstr=True, wrapin='[X]'
         (
+            '3',
+            "m",
+            None,
+            True,
+            "[X]",
+            (3 * 3.28083989501312, "[ft]"),
+        ),  # val, siunit, ipunit, unitstr, wrapin, expected
+        (
             3,
             "m",
             None,
@@ -260,6 +268,14 @@ def test_convert2ip(val, siunit, ipunit, unitstr, wrapin, expected):
             True,
             "[X]",
             ("autocalculate", "[m]"),
+        ),  # val, ipunit, siunit, unitstr, wrapin, expected
+        (
+            '3',
+            "lb/MWh",
+            "g/MJ",
+            True,
+            "[X]",
+            (3 / 7.93664091373665, "[g/MJ]"),
         ),  # val, ipunit, siunit, unitstr, wrapin, expected
         (
             3,

--- a/tests/test_epconversions.py
+++ b/tests/test_epconversions.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Santosh Philip
+# Copyright (c) 2023-2024 Santosh Philip
 # =======================================================================
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -122,7 +122,7 @@ from epconversions import epconversions
         ),  # val, siunit, ipunit, unitstr, wrapin, expected
         # unitstr=True, wrapin='[X]'
         (
-            '3',
+            "3",
             "m",
             None,
             True,
@@ -270,7 +270,7 @@ def test_convert2ip(val, siunit, ipunit, unitstr, wrapin, expected):
             ("autocalculate", "[m]"),
         ),  # val, ipunit, siunit, unitstr, wrapin, expected
         (
-            '3',
+            "3",
             "lb/MWh",
             "g/MJ",
             True,


### PR DESCRIPTION
:Problem: convert2ip and convert2si do not convert strings to floats
:Solution: strings are converted to floats if possible

    modified:   epconversions/epconversions.py
    modified:   tests/test_epconversions.py